### PR TITLE
Preserve zoom, pan, and mode across re-renders in standalone Mermaid diagrams

### DIFF
--- a/src/main/resources/web/mermaid-zoom.js
+++ b/src/main/resources/web/mermaid-zoom.js
@@ -324,7 +324,7 @@
 
     // ====== Standalone Mode ======
 
-    function initStandaloneZoom(shadowRoot, options) {
+    function initStandaloneZoom(shadowRoot, options, preservedState) {
         const fitMode = (options && options.fitMode) || 'fit';
         const toolbarEl = (options && options.toolbarEl) || null;
         const wheelRequiresModifier = (options && options.wheelRequiresModifier) || false;
@@ -374,7 +374,21 @@
             });
         }
 
-        applyTransform(state);
+        // Restore zoom across re-renders: same shadowRoot persists between renders of a
+        // standalone .mmd/.mermaid file, so the user's zoom/pan position should survive
+        // edits. If the user was in 'fit' mode, recompute fit for the new diagram dimensions
+        // rather than freezing the old fit scale.
+        if (preservedState && preservedState.mode === 'fit') {
+            fitToWindow(state);
+        } else if (preservedState) {
+            state.scale = preservedState.scale;
+            state.panX = preservedState.panX;
+            state.panY = preservedState.panY;
+            state.mode = preservedState.mode;
+            applyTransform(state);
+        } else {
+            applyTransform(state);
+        }
 
         attachViewportListeners(wrapped.viewport, state);
 
@@ -536,9 +550,19 @@
     window.__initMermaidZoom = function (shadowRoot, options) {
         if (!shadowRoot) return;
 
-        // Tear down previous instance for this shadowRoot (prevents listener accumulation on re-render)
+        // Tear down previous instance for this shadowRoot (prevents listener accumulation on re-render).
+        // Capture scale/pan/mode first so the user's zoom survives the re-render (standalone only —
+        // for inline mode the host element is recreated by IncrementalDOM, so the WeakMap miss naturally
+        // skips preservation).
+        let preservedState = null;
         const prev = stateMap.get(shadowRoot);
         if (prev) {
+            preservedState = {
+                scale: prev.scale,
+                panX: prev.panX,
+                panY: prev.panY,
+                mode: prev.mode
+            };
             if (prev.resizeObserver) prev.resizeObserver.disconnect();
             if (prev.keydownHandler) document.removeEventListener('keydown', prev.keydownHandler);
         }
@@ -546,7 +570,7 @@
         if (options && options.layoutMode === 'inline') {
             initInlineZoom(shadowRoot, options);
         } else {
-            initStandaloneZoom(shadowRoot, options);
+            initStandaloneZoom(shadowRoot, options, preservedState);
         }
     };
 

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
@@ -172,6 +172,42 @@ class MermaidZoomJsTest {
         fun `handles keyboard shortcuts`() {
             assertTrue(jsContent.contains("keydown"), "Should handle keyboard shortcuts")
         }
+
+        @Test
+        fun `preserves scale across re-renders`() {
+            assertTrue(
+                jsContent.contains("preservedState"),
+                "Should capture previous state under a 'preservedState' binding before tear-down"
+            )
+            assertTrue(
+                jsContent.contains("preservedState.scale"),
+                "Should restore the previous scale onto the new state on re-init"
+            )
+        }
+
+        @Test
+        fun `preserves pan across re-renders`() {
+            assertTrue(
+                jsContent.contains("preservedState.panX"),
+                "Should restore the previous panX onto the new state on re-init"
+            )
+            assertTrue(
+                jsContent.contains("preservedState.panY"),
+                "Should restore the previous panY onto the new state on re-init"
+            )
+        }
+
+        @Test
+        fun `preserves mode and re-fits when previous mode was fit`() {
+            assertTrue(
+                jsContent.contains("preservedState.mode"),
+                "Should restore (or branch on) the previous zoom mode on re-init"
+            )
+            assertTrue(
+                Regex("preservedState\\.mode\\s*===\\s*'fit'").containsMatchIn(jsContent),
+                "Should branch on previous mode === 'fit' to recompute fit for the new diagram dimensions"
+            )
+        }
     }
 
     // ====== Inline mode ======


### PR DESCRIPTION
- Update `mermaid-zoom.js` to capture and restore `scale`, `panX`, `panY`, and `mode` during re-renders.
- Add logic to recompute fit for diagrams when the previous mode was `fit`.
- Extend `MermaidZoomJsTest` with tests to verify zoom, pan, and mode preservation behavior.