### PR TITLE
Increase maximum zoom scale to 10.0 in Mermaid diagrams

### DIFF
--- a/src/main/resources/web/mermaid-zoom.js
+++ b/src/main/resources/web/mermaid-zoom.js
@@ -12,7 +12,7 @@
     // ====== Constants ======
 
     const MIN_SCALE = 0.1;
-    const MAX_SCALE = 5.0;
+    const MAX_SCALE = 10.0;
     const ZOOM_FACTOR = 1.25;
 
     // Per-shadowRoot state stored in a WeakMap

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
@@ -37,7 +37,7 @@ class MermaidZoomJsTest {
         @Test
         fun `clamps scale to min and max`() {
             assertTrue(jsContent.contains("0.1"), "Should have minimum scale of 0.1")
-            assertTrue(jsContent.contains("5.0"), "Should have maximum scale of 5.0")
+            assertTrue(jsContent.contains("10.0"), "Should have maximum scale of 10.0")
         }
 
         @Test


### PR DESCRIPTION
- Update `mermaid-zoom.js` to set `MAX_SCALE` constant to 10.0 (previously 5.0).
- Adjust `MermaidZoomJsTest` to reflect the updated maximum scale.