### PR TITLE
Add setting to allow user freely control the height of canvas

### DIFF
--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettings.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettings.kt
@@ -7,14 +7,18 @@ import com.intellij.openapi.components.Storage
 
 internal const val DEFAULT_MAX_TEXT_SIZE = 100_000
 internal const val DEFAULT_DEBOUNCE_MS = 300L
+internal const val DEFAULT_MAX_HEIGHT_PERCENT = 60
 
 internal const val MIN_MAX_TEXT_SIZE = 1_000
 internal const val MAX_MAX_TEXT_SIZE = 10_000_000
 internal const val MIN_DEBOUNCE_MS = 0L
 internal const val MAX_DEBOUNCE_MS = 5_000L
+internal const val MIN_MAX_HEIGHT_PERCENT = 20
+internal const val MAX_MAX_HEIGHT_PERCENT = 100
 
 internal fun clampMaxTextSize(value: Int): Int = value.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE)
 internal fun clampDebounceMs(value: Long): Long = value.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS)
+internal fun clampMaxHeightPercent(value: Int): Int = value.coerceIn(MIN_MAX_HEIGHT_PERCENT, MAX_MAX_HEIGHT_PERCENT)
 
 private fun jsonEscape(s: String): String = s
     .replace("\\", "\\\\")
@@ -30,10 +34,12 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         var fontFamily: MermaidFontFamily = MermaidFontFamily.DEFAULT,
         var maxTextSize: Int = DEFAULT_MAX_TEXT_SIZE,
         var debounceMs: Long = DEFAULT_DEBOUNCE_MS,
+        var maxHeightPercent: Int = DEFAULT_MAX_HEIGHT_PERCENT,
     ) {
         init {
             maxTextSize = maxTextSize.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE)
             debounceMs = debounceMs.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS)
+            maxHeightPercent = maxHeightPercent.coerceIn(MIN_MAX_HEIGHT_PERCENT, MAX_MAX_HEIGHT_PERCENT)
         }
     }
 
@@ -45,6 +51,7 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         myState = state.copy(
             maxTextSize = state.maxTextSize.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE),
             debounceMs = state.debounceMs.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS),
+            maxHeightPercent = state.maxHeightPercent.coerceIn(MIN_MAX_HEIGHT_PERCENT, MAX_MAX_HEIGHT_PERCENT),
         )
     }
 
@@ -63,6 +70,8 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         append(jsonEscape(myState.look.jsValue))
         append("\",\"maxTextSize\":")
         append(myState.maxTextSize)
+        append(",\"maxHeightPercent\":")
+        append(myState.maxHeightPercent)
         val font = myState.fontFamily
         if (font.cssValue != null) {
             append(",\"fontFamily\":\"")

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsConfigurable.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsConfigurable.kt
@@ -19,6 +19,7 @@ internal class MermaidSettingsConfigurable : Configurable {
     private var fontFamilySelection: MermaidFontFamily? = MermaidFontFamily.DEFAULT
     private var maxTextSizeText: String = DEFAULT_MAX_TEXT_SIZE.toString()
     private var debounceMsText: String = DEFAULT_DEBOUNCE_MS.toString()
+    private var maxHeightPercentText: String = DEFAULT_MAX_HEIGHT_PERCENT.toString()
 
     private var dialogPanel: DialogPanel? = null
 
@@ -87,6 +88,21 @@ internal class MermaidSettingsConfigurable : Configurable {
                         }
                         .comment(MyMessageBundle.message("settings.mermaid.debounce.comment"))
                 }
+                row(MyMessageBundle.message("settings.mermaid.maxHeightPercent.label")) {
+                    textField()
+                        .bindText(::maxHeightPercentText)
+                        .columns(6)
+                        .validationOnInput {
+                            val value = it.text.trim().toIntOrNull()
+                            when {
+                                value == null -> error(MyMessageBundle.message("settings.mermaid.validation.notANumber"))
+                                value !in MIN_MAX_HEIGHT_PERCENT..MAX_MAX_HEIGHT_PERCENT ->
+                                    warning(MyMessageBundle.message("settings.mermaid.maxHeightPercent.outOfRange"))
+                                else -> null
+                            }
+                        }
+                        .comment(MyMessageBundle.message("settings.mermaid.maxHeightPercent.comment"))
+                }
             }
         }
         dialogPanel = p
@@ -101,7 +117,8 @@ internal class MermaidSettingsConfigurable : Configurable {
             (lookSelection ?: MermaidLook.CLASSIC) != state.look ||
             (fontFamilySelection ?: MermaidFontFamily.DEFAULT) != state.fontFamily ||
             parseMaxTextSize() != state.maxTextSize ||
-            parseDebounceMs() != state.debounceMs
+            parseDebounceMs() != state.debounceMs ||
+            parseMaxHeightPercent() != state.maxHeightPercent
     }
 
     override fun apply() {
@@ -114,10 +131,12 @@ internal class MermaidSettingsConfigurable : Configurable {
             fontFamily = fontFamilySelection ?: MermaidFontFamily.DEFAULT,
             maxTextSize = parseMaxTextSize(),
             debounceMs = parseDebounceMs(),
+            maxHeightPercent = parseMaxHeightPercent(),
         )
         settings.loadState(newState)
         maxTextSizeText = settings.state.maxTextSize.toString()
         debounceMsText = settings.state.debounceMs.toString()
+        maxHeightPercentText = settings.state.maxHeightPercent.toString()
         if (settings.state != oldState) {
             ApplicationManager.getApplication().messageBus
                 .syncPublisher(MERMAID_SETTINGS_TOPIC)
@@ -137,6 +156,7 @@ internal class MermaidSettingsConfigurable : Configurable {
         fontFamilySelection = state.fontFamily
         maxTextSizeText = state.maxTextSize.toString()
         debounceMsText = state.debounceMs.toString()
+        maxHeightPercentText = state.maxHeightPercent.toString()
     }
 
     private fun parseMaxTextSize(): Int {
@@ -147,5 +167,10 @@ internal class MermaidSettingsConfigurable : Configurable {
     private fun parseDebounceMs(): Long {
         val raw = debounceMsText.trim().toLongOrNull() ?: DEFAULT_DEBOUNCE_MS
         return clampDebounceMs(raw)
+    }
+
+    private fun parseMaxHeightPercent(): Int {
+        val raw = maxHeightPercentText.trim().toIntOrNull() ?: DEFAULT_MAX_HEIGHT_PERCENT
+        return clampMaxHeightPercent(raw)
     }
 }

--- a/src/main/resources/messages/MyMessageBundle.properties
+++ b/src/main/resources/messages/MyMessageBundle.properties
@@ -53,6 +53,9 @@ settings.mermaid.maxTextSize.outOfRange=Value will be adjusted to the range 1,00
 settings.mermaid.debounce.label=Live reload delay:
 settings.mermaid.debounce.comment=Delay before re-rendering in ms (0\u20135000, 0\u2009=\u2009instant)
 settings.mermaid.debounce.outOfRange=Value will be adjusted to the range 0\u20135,000
+settings.mermaid.maxHeightPercent.label=Max preview height:
+settings.mermaid.maxHeightPercent.comment=Maximum diagram height as % of the window (20\u2013100)
+settings.mermaid.maxHeightPercent.outOfRange=Value will be adjusted to the range 20\u2013100
 settings.mermaid.validation.notANumber=Must be a valid number
 completion.mermaid.diagramType=Mermaid diagram
 completion.mermaid.keyword=Keyword

--- a/src/main/resources/web/mermaid-render.js
+++ b/src/main/resources/web/mermaid-render.js
@@ -98,7 +98,8 @@
                     window.__initMermaidZoom(container.shadowRoot, {
                         layoutMode: 'inline',
                         toolbarEl: container.shadowRoot.querySelector('.mermaid-export-toolbar'),
-                        wheelRequiresModifier: true
+                        wheelRequiresModifier: true,
+                        maxHeightPercent: (window.__MERMAID_CONFIG && window.__MERMAID_CONFIG.maxHeightPercent) || 60
                     });
                 }
             } else {

--- a/src/main/resources/web/mermaid-zoom.js
+++ b/src/main/resources/web/mermaid-zoom.js
@@ -418,12 +418,15 @@
     // Uses the SAME transform-based zoom/pan/fit as standalone.
     // Computes explicit viewport height because the host element in Markdown has no defined height
     // (unlike standalone's CSS 100vh). Two-phase sizing:
-    //   1. Cap proportional height at 60% of window (prevents diagram from dominating text)
+    //   1. Cap proportional height at maxHeightPercent of window (default 60%; prevents diagram from dominating text)
     //   2. After layout, expand if the page has available space (diagram-only fills the window)
 
     function initInlineZoom(shadowRoot, options) {
         const toolbarEl = (options && options.toolbarEl) || null;
         const wheelRequiresModifier = (options && options.wheelRequiresModifier) || false;
+        const maxHeightFraction =
+            (options && typeof options.maxHeightPercent === 'number' && options.maxHeightPercent > 0)
+                ? options.maxHeightPercent / 100 : 0.6;
 
         // Read SVG intrinsic dimensions before wrapping (needed for height computation)
         const tempSvg = shadowRoot.querySelector('svg');
@@ -435,13 +438,13 @@
         const wrapped = wrapInZoomViewport(shadowRoot);
         if (!wrapped) return;
 
-        // Phase 1: set viewport height from SVG proportions, capped at 60% of window.
+        // Phase 1: set viewport height from SVG proportions, capped at maxHeightFraction of window.
         // This ensures the diagram is contained when text surrounds it.
         function computeViewportHeight() {
             const vw = wrapped.viewport.clientWidth;
             if (vw <= 0 || intrinsic.width <= 0) return;
             const proportionalHeight = intrinsic.height * (vw / intrinsic.width);
-            const maxHeight = Math.max(300, window.innerHeight * 0.6);
+            const maxHeight = Math.max(300, window.innerHeight * maxHeightFraction);
             wrapped.viewport.style.height = Math.min(proportionalHeight, maxHeight) + 'px';
         }
 

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsTest.kt
@@ -24,6 +24,7 @@ class MermaidSettingsTest {
         assertEquals(MermaidFontFamily.DEFAULT, state.fontFamily)
         assertEquals(DEFAULT_MAX_TEXT_SIZE, state.maxTextSize)
         assertEquals(DEFAULT_DEBOUNCE_MS, state.debounceMs)
+        assertEquals(DEFAULT_MAX_HEIGHT_PERCENT, state.maxHeightPercent)
     }
 
     @Test
@@ -64,6 +65,7 @@ class MermaidSettingsTest {
         assertFalse(json.contains("\"fontFamily\""), "Default fontFamily should be omitted")
         assertTrue(json.contains("\"look\":\"classic\""))
         assertTrue(json.contains("\"maxTextSize\":100000"))
+        assertTrue(json.contains("\"maxHeightPercent\":60"))
     }
 
     @Test
@@ -119,6 +121,18 @@ class MermaidSettingsTest {
     }
 
     @Test
+    fun `loadState clamps maxHeightPercent below minimum`() {
+        settings.loadState(MermaidSettings.State(maxHeightPercent = 5))
+        assertEquals(MIN_MAX_HEIGHT_PERCENT, settings.state.maxHeightPercent)
+    }
+
+    @Test
+    fun `loadState clamps maxHeightPercent above maximum`() {
+        settings.loadState(MermaidSettings.State(maxHeightPercent = 250))
+        assertEquals(MAX_MAX_HEIGHT_PERCENT, settings.state.maxHeightPercent)
+    }
+
+    @Test
     fun `MermaidFontFamily enum has correct cssValues`() {
         assertNull(MermaidFontFamily.DEFAULT.cssValue)
         assertEquals("Arial", MermaidFontFamily.ARIAL.cssValue)
@@ -138,6 +152,7 @@ class MermaidSettingsTest {
             fontFamily = MermaidFontFamily.GEORGIA,
             maxTextSize = 50_000,
             debounceMs = 500,
+            maxHeightPercent = 40,
         )
         settings.loadState(original)
         val loaded = settings.state
@@ -146,6 +161,7 @@ class MermaidSettingsTest {
         assertEquals(MermaidFontFamily.GEORGIA, loaded.fontFamily)
         assertEquals(50_000, loaded.maxTextSize)
         assertEquals(500L, loaded.debounceMs)
+        assertEquals(40, loaded.maxHeightPercent)
     }
 
     @Test


### PR DESCRIPTION
Hi owner, please help me review this change.
I installed your plugin and it's really helpful to me except that I feel the height is not enough when I'm viewing a big diagram.
So I make this change to enable user to change height via a setting, hope it's helpful with oher users too