### PR TITLE
Add custom background/line colors and configurable canvas height

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ IntelliJ plugin for [Mermaid](https://mermaid.js.org/) diagrams — live preview
 
 ### Settings
 - Settings page (Settings > Tools > Mermaid) — theme, look (classic/hand-drawn), font family, max text size, live reload delay
+- **Custom rendering colors** — optionally override the visualizer background color and the line/edge color; disabled by default, so the rendering keeps following the IDE theme unless you opt in
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ IntelliJ plugin for [Mermaid](https://mermaid.js.org/) diagrams — live preview
 - **Render error annotations** — Mermaid.js parsing errors surfaced directly in the editor
 
 ### Settings
-- Settings page (Settings > Tools > Mermaid) — theme, look (classic/hand-drawn), font family, max text size, live reload delay
+- Settings page (Settings > Tools > Mermaid) — theme, look (classic/hand-drawn), font family, max text size, live reload delay, max preview height
 
 ## Requirements
 

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettings.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettings.kt
@@ -13,8 +13,16 @@ internal const val MAX_MAX_TEXT_SIZE = 10_000_000
 internal const val MIN_DEBOUNCE_MS = 0L
 internal const val MAX_DEBOUNCE_MS = 5_000L
 
+internal const val DEFAULT_BACKGROUND_COLOR = "#FFFFFF"
+internal const val DEFAULT_LINE_COLOR = "#888888"
+
 internal fun clampMaxTextSize(value: Int): Int = value.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE)
 internal fun clampDebounceMs(value: Long): Long = value.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS)
+
+private val HEX_COLOR_REGEX = Regex("^#[0-9a-fA-F]{6}$")
+
+internal fun normalizeHexColor(value: String, fallback: String): String =
+    if (HEX_COLOR_REGEX.matches(value)) value.uppercase() else fallback
 
 private fun jsonEscape(s: String): String = s
     .replace("\\", "\\\\")
@@ -30,10 +38,16 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         var fontFamily: MermaidFontFamily = MermaidFontFamily.DEFAULT,
         var maxTextSize: Int = DEFAULT_MAX_TEXT_SIZE,
         var debounceMs: Long = DEFAULT_DEBOUNCE_MS,
+        var overrideBackgroundColor: Boolean = false,
+        var backgroundColor: String = DEFAULT_BACKGROUND_COLOR,
+        var overrideLineColor: Boolean = false,
+        var lineColor: String = DEFAULT_LINE_COLOR,
     ) {
         init {
             maxTextSize = maxTextSize.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE)
             debounceMs = debounceMs.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS)
+            backgroundColor = normalizeHexColor(backgroundColor, DEFAULT_BACKGROUND_COLOR)
+            lineColor = normalizeHexColor(lineColor, DEFAULT_LINE_COLOR)
         }
     }
 
@@ -67,6 +81,16 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         if (font.cssValue != null) {
             append(",\"fontFamily\":\"")
             append(jsonEscape(font.cssValue))
+            append('"')
+        }
+        if (myState.overrideBackgroundColor) {
+            append(",\"backgroundColor\":\"")
+            append(normalizeHexColor(myState.backgroundColor, DEFAULT_BACKGROUND_COLOR))
+            append('"')
+        }
+        if (myState.overrideLineColor) {
+            append(",\"lineColor\":\"")
+            append(normalizeHexColor(myState.lineColor, DEFAULT_LINE_COLOR))
             append('"')
         }
         append('}')

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettings.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettings.kt
@@ -7,14 +7,18 @@ import com.intellij.openapi.components.Storage
 
 internal const val DEFAULT_MAX_TEXT_SIZE = 100_000
 internal const val DEFAULT_DEBOUNCE_MS = 300L
+internal const val DEFAULT_MAX_HEIGHT_PERCENT = 60
 
 internal const val MIN_MAX_TEXT_SIZE = 1_000
 internal const val MAX_MAX_TEXT_SIZE = 10_000_000
 internal const val MIN_DEBOUNCE_MS = 0L
 internal const val MAX_DEBOUNCE_MS = 5_000L
+internal const val MIN_MAX_HEIGHT_PERCENT = 20
+internal const val MAX_MAX_HEIGHT_PERCENT = 100
 
 internal fun clampMaxTextSize(value: Int): Int = value.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE)
 internal fun clampDebounceMs(value: Long): Long = value.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS)
+internal fun clampMaxHeightPercent(value: Int): Int = value.coerceIn(MIN_MAX_HEIGHT_PERCENT, MAX_MAX_HEIGHT_PERCENT)
 
 private fun jsonEscape(s: String): String = s
     .replace("\\", "\\\\")
@@ -30,10 +34,12 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         var fontFamily: MermaidFontFamily = MermaidFontFamily.DEFAULT,
         var maxTextSize: Int = DEFAULT_MAX_TEXT_SIZE,
         var debounceMs: Long = DEFAULT_DEBOUNCE_MS,
+        var maxHeightPercent: Int = DEFAULT_MAX_HEIGHT_PERCENT,
     ) {
         init {
             maxTextSize = maxTextSize.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE)
             debounceMs = debounceMs.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS)
+            maxHeightPercent = maxHeightPercent.coerceIn(MIN_MAX_HEIGHT_PERCENT, MAX_MAX_HEIGHT_PERCENT)
         }
     }
 
@@ -45,6 +51,7 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         myState = state.copy(
             maxTextSize = state.maxTextSize.coerceIn(MIN_MAX_TEXT_SIZE, MAX_MAX_TEXT_SIZE),
             debounceMs = state.debounceMs.coerceIn(MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS),
+            maxHeightPercent = state.maxHeightPercent.coerceIn(MIN_MAX_HEIGHT_PERCENT, MAX_MAX_HEIGHT_PERCENT),
         )
     }
 
@@ -63,6 +70,8 @@ internal class MermaidSettings : PersistentStateComponent<MermaidSettings.State>
         append(jsonEscape(myState.look.jsValue))
         append("\",\"maxTextSize\":")
         append(myState.maxTextSize)
+        append(",\"maxHeightPercent\":")
+        append(myState.maxHeightPercent)
         val font = myState.fontFamily
         if (font.cssValue != null) {
             append(",\"fontFamily\":\"")

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsConfigurable.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsConfigurable.kt
@@ -5,11 +5,15 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.ColorPanel
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.columns
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.selected
+import java.awt.Color
 import javax.swing.JComponent
 
 internal class MermaidSettingsConfigurable : Configurable {
@@ -19,6 +23,13 @@ internal class MermaidSettingsConfigurable : Configurable {
     private var fontFamilySelection: MermaidFontFamily? = MermaidFontFamily.DEFAULT
     private var maxTextSizeText: String = DEFAULT_MAX_TEXT_SIZE.toString()
     private var debounceMsText: String = DEFAULT_DEBOUNCE_MS.toString()
+    private var overrideBackgroundSelection: Boolean = false
+    private var backgroundColorHex: String = DEFAULT_BACKGROUND_COLOR
+    private var overrideLineColorSelection: Boolean = false
+    private var lineColorHex: String = DEFAULT_LINE_COLOR
+
+    private var backgroundColorPanel: ColorPanel? = null
+    private var lineColorPanel: ColorPanel? = null
 
     private var dialogPanel: DialogPanel? = null
 
@@ -27,6 +38,11 @@ internal class MermaidSettingsConfigurable : Configurable {
     override fun createComponent(): JComponent {
         val settings = service<MermaidSettings>()
         loadFromState(settings.state)
+
+        val bgPanel = ColorPanel().apply { selectedColor = parseColor(backgroundColorHex, DEFAULT_BACKGROUND_COLOR) }
+        val linePanel = ColorPanel().apply { selectedColor = parseColor(lineColorHex, DEFAULT_LINE_COLOR) }
+        backgroundColorPanel = bgPanel
+        lineColorPanel = linePanel
 
         val p = panel {
             group(MyMessageBundle.message("settings.mermaid.group.rendering")) {
@@ -88,6 +104,18 @@ internal class MermaidSettingsConfigurable : Configurable {
                         .comment(MyMessageBundle.message("settings.mermaid.debounce.comment"))
                 }
             }
+            group(MyMessageBundle.message("settings.mermaid.group.colors")) {
+                row {
+                    val bgCheck = checkBox(MyMessageBundle.message("settings.mermaid.backgroundColor.label"))
+                        .bindSelected(::overrideBackgroundSelection)
+                    cell(bgPanel).enabledIf(bgCheck.selected)
+                }.rowComment(MyMessageBundle.message("settings.mermaid.backgroundColor.comment"))
+                row {
+                    val lineCheck = checkBox(MyMessageBundle.message("settings.mermaid.lineColor.label"))
+                        .bindSelected(::overrideLineColorSelection)
+                    cell(linePanel).enabledIf(lineCheck.selected)
+                }.rowComment(MyMessageBundle.message("settings.mermaid.lineColor.comment"))
+            }
         }
         dialogPanel = p
         return p
@@ -101,7 +129,11 @@ internal class MermaidSettingsConfigurable : Configurable {
             (lookSelection ?: MermaidLook.CLASSIC) != state.look ||
             (fontFamilySelection ?: MermaidFontFamily.DEFAULT) != state.fontFamily ||
             parseMaxTextSize() != state.maxTextSize ||
-            parseDebounceMs() != state.debounceMs
+            parseDebounceMs() != state.debounceMs ||
+            overrideBackgroundSelection != state.overrideBackgroundColor ||
+            currentBackgroundHex() != state.backgroundColor ||
+            overrideLineColorSelection != state.overrideLineColor ||
+            currentLineColorHex() != state.lineColor
     }
 
     override fun apply() {
@@ -114,10 +146,16 @@ internal class MermaidSettingsConfigurable : Configurable {
             fontFamily = fontFamilySelection ?: MermaidFontFamily.DEFAULT,
             maxTextSize = parseMaxTextSize(),
             debounceMs = parseDebounceMs(),
+            overrideBackgroundColor = overrideBackgroundSelection,
+            backgroundColor = currentBackgroundHex(),
+            overrideLineColor = overrideLineColorSelection,
+            lineColor = currentLineColorHex(),
         )
         settings.loadState(newState)
         maxTextSizeText = settings.state.maxTextSize.toString()
         debounceMsText = settings.state.debounceMs.toString()
+        backgroundColorHex = settings.state.backgroundColor
+        lineColorHex = settings.state.lineColor
         if (settings.state != oldState) {
             ApplicationManager.getApplication().messageBus
                 .syncPublisher(MERMAID_SETTINGS_TOPIC)
@@ -137,7 +175,29 @@ internal class MermaidSettingsConfigurable : Configurable {
         fontFamilySelection = state.fontFamily
         maxTextSizeText = state.maxTextSize.toString()
         debounceMsText = state.debounceMs.toString()
+        overrideBackgroundSelection = state.overrideBackgroundColor
+        backgroundColorHex = state.backgroundColor
+        overrideLineColorSelection = state.overrideLineColor
+        lineColorHex = state.lineColor
+        backgroundColorPanel?.selectedColor = parseColor(backgroundColorHex, DEFAULT_BACKGROUND_COLOR)
+        lineColorPanel?.selectedColor = parseColor(lineColorHex, DEFAULT_LINE_COLOR)
     }
+
+    private fun currentBackgroundHex(): String =
+        colorToHex(backgroundColorPanel?.selectedColor, DEFAULT_BACKGROUND_COLOR)
+
+    private fun currentLineColorHex(): String =
+        colorToHex(lineColorPanel?.selectedColor, DEFAULT_LINE_COLOR)
+
+    private fun colorToHex(color: Color?, fallback: String): String =
+        if (color == null) fallback else "#%02X%02X%02X".format(color.red, color.green, color.blue)
+
+    private fun parseColor(hex: String, fallback: String): Color =
+        try {
+            Color.decode(normalizeHexColor(hex, fallback))
+        } catch (_: NumberFormatException) {
+            Color.decode(fallback)
+        }
 
     private fun parseMaxTextSize(): Int {
         val raw = maxTextSizeText.trim().toIntOrNull() ?: DEFAULT_MAX_TEXT_SIZE

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsConfigurable.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsConfigurable.kt
@@ -19,6 +19,7 @@ internal class MermaidSettingsConfigurable : Configurable {
     private var fontFamilySelection: MermaidFontFamily? = MermaidFontFamily.DEFAULT
     private var maxTextSizeText: String = DEFAULT_MAX_TEXT_SIZE.toString()
     private var debounceMsText: String = DEFAULT_DEBOUNCE_MS.toString()
+    private var maxHeightPercentText: String = DEFAULT_MAX_HEIGHT_PERCENT.toString()
 
     private var dialogPanel: DialogPanel? = null
 
@@ -87,6 +88,21 @@ internal class MermaidSettingsConfigurable : Configurable {
                         }
                         .comment(MyMessageBundle.message("settings.mermaid.debounce.comment"))
                 }
+                row(MyMessageBundle.message("settings.mermaid.maxHeightPercent.label")) {
+                    textField()
+                        .bindText(::maxHeightPercentText)
+                        .columns(6)
+                        .validationOnInput {
+                            val value = it.text.trim().toIntOrNull()
+                            when {
+                                value == null -> error(MyMessageBundle.message("settings.mermaid.validation.notANumber"))
+                                value !in MIN_MAX_HEIGHT_PERCENT..MAX_MAX_HEIGHT_PERCENT ->
+                                    warning(MyMessageBundle.message("settings.mermaid.maxHeightPercent.outOfRange"))
+                                else -> null
+                            }
+                        }
+                        .comment(MyMessageBundle.message("settings.mermaid.maxHeightPercent.comment"))
+                }
             }
         }
         dialogPanel = p
@@ -101,7 +117,8 @@ internal class MermaidSettingsConfigurable : Configurable {
             (lookSelection ?: MermaidLook.CLASSIC) != state.look ||
             (fontFamilySelection ?: MermaidFontFamily.DEFAULT) != state.fontFamily ||
             parseMaxTextSize() != state.maxTextSize ||
-            parseDebounceMs() != state.debounceMs
+            parseDebounceMs() != state.debounceMs ||
+            parseMaxHeightPercent() != state.maxHeightPercent
     }
 
     override fun apply() {
@@ -114,10 +131,12 @@ internal class MermaidSettingsConfigurable : Configurable {
             fontFamily = fontFamilySelection ?: MermaidFontFamily.DEFAULT,
             maxTextSize = parseMaxTextSize(),
             debounceMs = parseDebounceMs(),
+            maxHeightPercent = parseMaxHeightPercent(),
         )
         settings.loadState(newState)
         maxTextSizeText = settings.state.maxTextSize.toString()
         debounceMsText = settings.state.debounceMs.toString()
+        maxHeightPercentText = settings.state.maxHeightPercent.toString()
         if (settings.state != oldState) {
             ApplicationManager.getApplication().messageBus
                 .syncPublisher(MERMAID_SETTINGS_TOPIC)
@@ -137,6 +156,7 @@ internal class MermaidSettingsConfigurable : Configurable {
         fontFamilySelection = state.fontFamily
         maxTextSizeText = state.maxTextSize.toString()
         debounceMsText = state.debounceMs.toString()
+        maxHeightPercentText = state.maxHeightPercent.toString()
     }
 
     private fun parseMaxTextSize(): Int {
@@ -147,5 +167,10 @@ internal class MermaidSettingsConfigurable : Configurable {
     private fun parseDebounceMs(): Long {
         val raw = debounceMsText.trim().toLongOrNull() ?: DEFAULT_DEBOUNCE_MS
         return clampDebounceMs(raw)
+    }
+
+    private fun parseMaxHeightPercent(): Int {
+        val raw = maxHeightPercentText.trim().toIntOrNull() ?: DEFAULT_MAX_HEIGHT_PERCENT
+        return clampMaxHeightPercent(raw)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,7 +30,7 @@
         </ul>
 
         <h2>Settings</h2>
-        <p>Configurable via <code>Settings &gt; Tools &gt; Mermaid</code> — theme, look (classic/hand-drawn), font family, max text size, live reload delay.</p>
+        <p>Configurable via <code>Settings &gt; Tools &gt; Mermaid</code> — theme, look (classic/hand-drawn), font family, max text size, live reload delay, max preview height.</p>
         <p>Customizable colors via <code>Settings &gt; Editor &gt; Color Scheme &gt; Mermaid</code>.</p>
 
         <h2>Usage</h2>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,7 +31,8 @@
 
         <h2>Settings</h2>
         <p>Configurable via <code>Settings &gt; Tools &gt; Mermaid</code> — theme, look (classic/hand-drawn), font family, max text size, live reload delay.</p>
-        <p>Customizable colors via <code>Settings &gt; Editor &gt; Color Scheme &gt; Mermaid</code>.</p>
+        <p>Custom rendering colors — optionally override the visualizer background color and the line/edge color (disabled by default, so the rendering keeps following your IDE theme unless you opt in).</p>
+        <p>Customizable syntax colors via <code>Settings &gt; Editor &gt; Color Scheme &gt; Mermaid</code>.</p>
 
         <h2>Usage</h2>
         <p>Write a <code>```mermaid</code> fenced code block in any Markdown file and open the preview, or open any <code>.mmd</code>/<code>.mermaid</code> file.</p>

--- a/src/main/resources/messages/MyMessageBundle.properties
+++ b/src/main/resources/messages/MyMessageBundle.properties
@@ -54,6 +54,11 @@ settings.mermaid.debounce.label=Live reload delay:
 settings.mermaid.debounce.comment=Delay before re-rendering in ms (0\u20135000, 0\u2009=\u2009instant)
 settings.mermaid.debounce.outOfRange=Value will be adjusted to the range 0\u20135,000
 settings.mermaid.validation.notANumber=Must be a valid number
+settings.mermaid.group.colors=Colors
+settings.mermaid.backgroundColor.label=Custom background color
+settings.mermaid.backgroundColor.comment=Override the rendering background color instead of following the IDE theme
+settings.mermaid.lineColor.label=Custom line color
+settings.mermaid.lineColor.comment=Override the color of lines and edges (flowchart/graph diagrams)
 completion.mermaid.diagramType=Mermaid diagram
 completion.mermaid.keyword=Keyword
 completion.mermaid.node=Node

--- a/src/main/resources/messages/MyMessageBundle.properties
+++ b/src/main/resources/messages/MyMessageBundle.properties
@@ -53,6 +53,9 @@ settings.mermaid.maxTextSize.outOfRange=Value will be adjusted to the range 1,00
 settings.mermaid.debounce.label=Live reload delay:
 settings.mermaid.debounce.comment=Delay before re-rendering in ms (0\u20135000, 0\u2009=\u2009instant)
 settings.mermaid.debounce.outOfRange=Value will be adjusted to the range 0\u20135,000
+settings.mermaid.maxHeightPercent.label=Max preview height:
+settings.mermaid.maxHeightPercent.comment=Maximum diagram height as % of the window (20\u2013100)
+settings.mermaid.maxHeightPercent.outOfRange=Value will be adjusted to the range 20\u2013100
 settings.mermaid.validation.notANumber=Must be a valid number
 completion.mermaid.diagramType=Mermaid diagram
 completion.mermaid.keyword=Keyword

--- a/src/main/resources/web/mermaid-core.js
+++ b/src/main/resources/web/mermaid-core.js
@@ -100,6 +100,12 @@
             securityLevel: 'strict'
         };
         if (cfg.fontFamily) opts.fontFamily = cfg.fontFamily;
+        if (cfg.lineColor) {
+            // themeVariables.lineColor overrides the chosen theme's edge/line color.
+            // Primarily affects flowchart/graph edges; other diagram types use their own variables.
+            opts.themeVariables = opts.themeVariables || {};
+            opts.themeVariables.lineColor = cfg.lineColor;
+        }
         mermaid.initialize(opts);
     }
 
@@ -124,7 +130,7 @@
         };
     }
 
-    function createPngCanvas(width, height, scale, isDark) {
+    function createPngCanvas(width, height, scale, bgColor) {
         const canvas = document.createElement('canvas');
         canvas.width = Math.ceil(width * scale);
         canvas.height = Math.ceil(height * scale);
@@ -133,7 +139,7 @@
             console.error('[MermaidVisualizer] Failed to get 2D canvas context');
             return null;
         }
-        ctx.fillStyle = isDark ? '#2b2b2b' : '#ffffff';
+        ctx.fillStyle = bgColor;
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         return { canvas: canvas, ctx: ctx };
     }
@@ -160,6 +166,7 @@
 
     // scale: multiplier for HiDPI output (2 = 2x resolution). Fallback 800x600 when SVG has no measured size.
     // isDarkFn: function returning boolean — abstracts theme detection per context.
+    // A custom background color (cfg.backgroundColor) takes precedence over the theme-derived default.
     function extractPng(container, scale, isDarkFn, callback) {
         const svgString = extractSvg(container);
         if (!svgString) { callback(''); return; }
@@ -167,8 +174,10 @@
         const renderedSvg = container.shadowRoot.querySelector('svg');
         if (!renderedSvg) { callback(''); return; }
 
+        const cfg = window.__MERMAID_CONFIG || {};
+        const bgColor = cfg.backgroundColor || (isDarkFn() ? '#2b2b2b' : '#ffffff');
         const dim = getSvgDimensions(renderedSvg);
-        const canvasInfo = createPngCanvas(dim.w, dim.h, scale, isDarkFn());
+        const canvasInfo = createPngCanvas(dim.w, dim.h, scale, bgColor);
         if (!canvasInfo) { callback(''); return; }
 
         const svgDataUrl = 'data:image/svg+xml;base64,' + utf8ToBase64(svgString);

--- a/src/main/resources/web/mermaid-render.js
+++ b/src/main/resources/web/mermaid-render.js
@@ -98,7 +98,8 @@
                     window.__initMermaidZoom(container.shadowRoot, {
                         layoutMode: 'inline',
                         toolbarEl: container.shadowRoot.querySelector('.mermaid-export-toolbar'),
-                        wheelRequiresModifier: true
+                        wheelRequiresModifier: true,
+                        maxHeightPercent: (window.__MERMAID_CONFIG && window.__MERMAID_CONFIG.maxHeightPercent) || 60
                     });
                 }
             } else {

--- a/src/main/resources/web/mermaid-render.js
+++ b/src/main/resources/web/mermaid-render.js
@@ -87,6 +87,8 @@
 
     async function renderSingleDiagram(container, source, isDark) {
         const core = window.__mermaidCore;
+        const cfg = window.__MERMAID_CONFIG || {};
+        container.style.background = cfg.backgroundColor || '';
         const renderId = core.nextRenderId();
         try {
             const result = await mermaid.render(renderId, source);

--- a/src/main/resources/web/mermaid-standalone.js
+++ b/src/main/resources/web/mermaid-standalone.js
@@ -52,6 +52,11 @@
         }
     }
 
+    function applyBackground() {
+        const cfg = window.__MERMAID_CONFIG || {};
+        document.body.style.background = cfg.backgroundColor || '';
+    }
+
     window.renderDiagram = async function (base64Source, forceThemeRefresh, generation) {
         const container = document.getElementById('mermaid-container');
         if (!container) {
@@ -59,6 +64,8 @@
             reportRenderResult({ status: 'error', message: 'Internal error: container not found', line: null, column: null }, generation);
             return;
         }
+
+        applyBackground();
 
         const isDark = document.body.classList.contains('dark-theme');
         const autoTheme = isDark ? 'dark' : 'default';

--- a/src/main/resources/web/mermaid-zoom.js
+++ b/src/main/resources/web/mermaid-zoom.js
@@ -418,12 +418,15 @@
     // Uses the SAME transform-based zoom/pan/fit as standalone.
     // Computes explicit viewport height because the host element in Markdown has no defined height
     // (unlike standalone's CSS 100vh). Two-phase sizing:
-    //   1. Cap proportional height at 60% of window (prevents diagram from dominating text)
+    //   1. Cap proportional height at maxHeightPercent of window (default 60%; prevents diagram from dominating text)
     //   2. After layout, expand if the page has available space (diagram-only fills the window)
 
     function initInlineZoom(shadowRoot, options) {
         const toolbarEl = (options && options.toolbarEl) || null;
         const wheelRequiresModifier = (options && options.wheelRequiresModifier) || false;
+        const maxHeightFraction =
+            (options && typeof options.maxHeightPercent === 'number' && options.maxHeightPercent > 0)
+                ? options.maxHeightPercent / 100 : 0.6;
 
         // Read SVG intrinsic dimensions before wrapping (needed for height computation)
         const tempSvg = shadowRoot.querySelector('svg');
@@ -435,13 +438,13 @@
         const wrapped = wrapInZoomViewport(shadowRoot);
         if (!wrapped) return;
 
-        // Phase 1: set viewport height from SVG proportions, capped at 60% of window.
+        // Phase 1: set viewport height from SVG proportions, capped at maxHeightFraction of window.
         // This ensures the diagram is contained when text surrounds it.
         function computeViewportHeight() {
             const vw = wrapped.viewport.clientWidth;
             if (vw <= 0 || intrinsic.width <= 0) return;
             const proportionalHeight = intrinsic.height * (vw / intrinsic.width);
-            const maxHeight = Math.max(300, window.innerHeight * 0.6);
+            const maxHeight = Math.max(300, window.innerHeight * maxHeightFraction);
             wrapped.viewport.style.height = Math.min(proportionalHeight, maxHeight) + 'px';
         }
 

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidCoreJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidCoreJsTest.kt
@@ -81,6 +81,22 @@ class MermaidCoreJsTest {
     }
 
     @Test
+    fun `core js initMermaid applies custom line color via themeVariables`() {
+        assertTrue(jsContent.contains("cfg.lineColor"), "initMermaid should read cfg.lineColor")
+        assertTrue(jsContent.contains("themeVariables"), "Custom line color should be applied via themeVariables")
+        assertTrue(jsContent.contains("opts.themeVariables.lineColor"), "Should set themeVariables.lineColor")
+    }
+
+    @Test
+    fun `core js extractPng honors custom background color`() {
+        assertTrue(jsContent.contains("cfg.backgroundColor"), "extractPng should read cfg.backgroundColor")
+        assertTrue(
+            jsContent.contains("cfg.backgroundColor || (isDarkFn()"),
+            "Custom background should take precedence over the theme-derived default"
+        )
+    }
+
+    @Test
     fun `core js extractSvg uses XMLSerializer and xmlns`() {
         assertTrue(jsContent.contains("extractSvg"), "Should have extractSvg function")
         assertTrue(jsContent.contains("XMLSerializer"), "Should use XMLSerializer to serialize SVG")

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidStandaloneJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidStandaloneJsTest.kt
@@ -56,6 +56,13 @@ class MermaidStandaloneJsTest {
     }
 
     @Test
+    fun `standalone js applies custom background color from config`() {
+        assertTrue(jsContent.contains("applyBackground"), "Should have applyBackground function")
+        assertTrue(jsContent.contains("document.body.style.background"), "Should set body background from config")
+        assertTrue(jsContent.contains("cfg.backgroundColor || ''"), "Should clear inline background when no override is set")
+    }
+
+    @Test
     fun `standalone js exposes scroll sync public contract`() {
         assertTrue(jsContent.contains("window.__scrollPreviewTo"), "Should expose __scrollPreviewTo for Kotlin->JS scroll sync")
         assertTrue(jsContent.contains("__mermaidScrollBridge"), "Should reference __mermaidScrollBridge for JS->Kotlin scroll sync")

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
@@ -316,5 +316,37 @@ class MermaidZoomJsTest {
                 "Inline ResizeObserver should track width to avoid infinite loops from height changes"
             )
         }
+
+        @Test
+        fun `derives maxHeightFraction from maxHeightPercent option`() {
+            assertTrue(
+                jsContent.contains("options.maxHeightPercent"),
+                "Inline mode should read the maxHeightPercent option"
+            )
+            assertTrue(
+                jsContent.contains("maxHeightFraction"),
+                "Inline mode should derive a maxHeightFraction from the percent option"
+            )
+            assertTrue(
+                jsContent.contains("options.maxHeightPercent / 100"),
+                "maxHeightPercent should be converted from a percent to a 0-1 fraction"
+            )
+        }
+
+        @Test
+        fun `falls back to 0_6 fraction when maxHeightPercent absent`() {
+            assertTrue(
+                Regex(":\\s*0\\.6").containsMatchIn(jsContent),
+                "Inline mode should fall back to 0.6 (60%) when no maxHeightPercent is provided"
+            )
+        }
+
+        @Test
+        fun `caps viewport height using maxHeightFraction`() {
+            assertTrue(
+                jsContent.contains("window.innerHeight * maxHeightFraction"),
+                "Viewport height cap should use the configurable maxHeightFraction"
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
@@ -44,6 +44,15 @@ class MermaidRenderJsExportTest {
     }
 
     @Test
+    fun `render js applies custom background color per diagram container`() {
+        assertTrue(jsContent.contains("cfg.backgroundColor"), "Should read cfg.backgroundColor")
+        assertTrue(
+            jsContent.contains("container.style.background = cfg.backgroundColor || ''"),
+            "Background should be scoped to the diagram container and cleared when no override is set"
+        )
+    }
+
+    @Test
     fun `render js has messagePipe guard`() {
         assertTrue(jsContent.contains("__IntelliJTools"), "Should check for __IntelliJTools")
         assertTrue(jsContent.contains("messagePipe"), "Should check for messagePipe")

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
@@ -44,6 +44,15 @@ class MermaidRenderJsExportTest {
     }
 
     @Test
+    fun `render js passes maxHeightPercent from config to inline zoom`() {
+        assertTrue(jsContent.contains("maxHeightPercent"), "Should pass maxHeightPercent to the zoom init")
+        assertTrue(
+            jsContent.contains("(window.__MERMAID_CONFIG && window.__MERMAID_CONFIG.maxHeightPercent) || 60"),
+            "Max preview height should be read from __MERMAID_CONFIG with a default fallback"
+        )
+    }
+
+    @Test
     fun `render js has messagePipe guard`() {
         assertTrue(jsContent.contains("__IntelliJTools"), "Should check for __IntelliJTools")
         assertTrue(jsContent.contains("messagePipe"), "Should check for messagePipe")

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsTest.kt
@@ -24,6 +24,7 @@ class MermaidSettingsTest {
         assertEquals(MermaidFontFamily.DEFAULT, state.fontFamily)
         assertEquals(DEFAULT_MAX_TEXT_SIZE, state.maxTextSize)
         assertEquals(DEFAULT_DEBOUNCE_MS, state.debounceMs)
+        assertEquals(DEFAULT_MAX_HEIGHT_PERCENT, state.maxHeightPercent)
     }
 
     @Test
@@ -64,6 +65,7 @@ class MermaidSettingsTest {
         assertFalse(json.contains("\"fontFamily\""), "Default fontFamily should be omitted")
         assertTrue(json.contains("\"look\":\"classic\""))
         assertTrue(json.contains("\"maxTextSize\":100000"))
+        assertTrue(json.contains("\"maxHeightPercent\":60"))
     }
 
     @Test
@@ -119,6 +121,18 @@ class MermaidSettingsTest {
     }
 
     @Test
+    fun `loadState clamps maxHeightPercent below minimum`() {
+        settings.loadState(MermaidSettings.State(maxHeightPercent = 5))
+        assertEquals(MIN_MAX_HEIGHT_PERCENT, settings.state.maxHeightPercent)
+    }
+
+    @Test
+    fun `loadState clamps maxHeightPercent above maximum`() {
+        settings.loadState(MermaidSettings.State(maxHeightPercent = 250))
+        assertEquals(MAX_MAX_HEIGHT_PERCENT, settings.state.maxHeightPercent)
+    }
+
+    @Test
     fun `MermaidFontFamily enum has correct cssValues`() {
         assertNull(MermaidFontFamily.DEFAULT.cssValue)
         assertEquals("Arial", MermaidFontFamily.ARIAL.cssValue)
@@ -138,6 +152,7 @@ class MermaidSettingsTest {
             fontFamily = MermaidFontFamily.GEORGIA,
             maxTextSize = 50_000,
             debounceMs = 500,
+            maxHeightPercent = 40,
         )
         settings.loadState(original)
         val loaded = settings.state
@@ -146,6 +161,7 @@ class MermaidSettingsTest {
         assertEquals(MermaidFontFamily.GEORGIA, loaded.fontFamily)
         assertEquals(50_000, loaded.maxTextSize)
         assertEquals(500L, loaded.debounceMs)
+        assertEquals(40, loaded.maxHeightPercent)
     }
 
     @Test

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/settings/MermaidSettingsTest.kt
@@ -24,6 +24,10 @@ class MermaidSettingsTest {
         assertEquals(MermaidFontFamily.DEFAULT, state.fontFamily)
         assertEquals(DEFAULT_MAX_TEXT_SIZE, state.maxTextSize)
         assertEquals(DEFAULT_DEBOUNCE_MS, state.debounceMs)
+        assertFalse(state.overrideBackgroundColor)
+        assertEquals(DEFAULT_BACKGROUND_COLOR, state.backgroundColor)
+        assertFalse(state.overrideLineColor)
+        assertEquals(DEFAULT_LINE_COLOR, state.lineColor)
     }
 
     @Test
@@ -64,6 +68,68 @@ class MermaidSettingsTest {
         assertFalse(json.contains("\"fontFamily\""), "Default fontFamily should be omitted")
         assertTrue(json.contains("\"look\":\"classic\""))
         assertTrue(json.contains("\"maxTextSize\":100000"))
+    }
+
+    @Test
+    fun `toJsConfigJson omits colors when override disabled`() {
+        settings.loadState(MermaidSettings.State(backgroundColor = "#123456", lineColor = "#abcdef"))
+        val json = settings.toJsConfigJson()
+        assertFalse(json.contains("backgroundColor"), "Background color should be omitted when override is off")
+        assertFalse(json.contains("lineColor"), "Line color should be omitted when override is off")
+    }
+
+    @Test
+    fun `toJsConfigJson includes background color when override enabled`() {
+        settings.loadState(MermaidSettings.State(overrideBackgroundColor = true, backgroundColor = "#101820"))
+        val json = settings.toJsConfigJson()
+        assertTrue(json.contains("\"backgroundColor\":\"#101820\""), "Should emit background color: $json")
+    }
+
+    @Test
+    fun `toJsConfigJson includes line color when override enabled`() {
+        settings.loadState(MermaidSettings.State(overrideLineColor = true, lineColor = "#FF8800"))
+        val json = settings.toJsConfigJson()
+        assertTrue(json.contains("\"lineColor\":\"#FF8800\""), "Should emit line color: $json")
+    }
+
+    @Test
+    fun `normalizeHexColor accepts valid hex and uppercases`() {
+        assertEquals("#1A2B3C", normalizeHexColor("#1a2b3c", DEFAULT_BACKGROUND_COLOR))
+        assertEquals("#FFFFFF", normalizeHexColor("#FFFFFF", DEFAULT_BACKGROUND_COLOR))
+    }
+
+    @Test
+    fun `normalizeHexColor rejects invalid input and returns fallback`() {
+        assertEquals(DEFAULT_BACKGROUND_COLOR, normalizeHexColor("not-a-color", DEFAULT_BACKGROUND_COLOR))
+        assertEquals(DEFAULT_BACKGROUND_COLOR, normalizeHexColor("#12345", DEFAULT_BACKGROUND_COLOR))
+        assertEquals(DEFAULT_BACKGROUND_COLOR, normalizeHexColor("#1234567", DEFAULT_BACKGROUND_COLOR))
+        assertEquals(DEFAULT_BACKGROUND_COLOR, normalizeHexColor("red", DEFAULT_BACKGROUND_COLOR))
+        // Injection attempt must not survive normalization
+        assertEquals(DEFAULT_BACKGROUND_COLOR, normalizeHexColor("#000\";alert(1)//", DEFAULT_BACKGROUND_COLOR))
+    }
+
+    @Test
+    fun `loadState normalizes invalid persisted colors`() {
+        settings.loadState(MermaidSettings.State(backgroundColor = "garbage", lineColor = "#zzz"))
+        assertEquals(DEFAULT_BACKGROUND_COLOR, settings.state.backgroundColor)
+        assertEquals(DEFAULT_LINE_COLOR, settings.state.lineColor)
+    }
+
+    @Test
+    fun `color state round-trip preserves values`() {
+        settings.loadState(
+            MermaidSettings.State(
+                overrideBackgroundColor = true,
+                backgroundColor = "#0A0B0C",
+                overrideLineColor = true,
+                lineColor = "#0D0E0F",
+            )
+        )
+        val loaded = settings.state
+        assertTrue(loaded.overrideBackgroundColor)
+        assertEquals("#0A0B0C", loaded.backgroundColor)
+        assertTrue(loaded.overrideLineColor)
+        assertEquals("#0D0E0F", loaded.lineColor)
     }
 
     @Test


### PR DESCRIPTION
- Introduced options for overriding the rendering background and line/edge colors in Mermaid diagrams.
- Updated settings UI with color pickers and controls for toggling custom color overrides.
- Enhanced `MermaidSettings` to support color normalization and validation.
- Updated `mermaid-core.js` and `mermaid-standalone.js` to apply custom colors during rendering.
- Added test coverage for color configuration, persistence, and rendering behavior.