### PR TITLE
Open Mermaid click command links in the system browser

### DIFF
--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/MermaidLinkOpener.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/MermaidLinkOpener.kt
@@ -1,0 +1,41 @@
+package com.alextdev.mermaidvisualizer
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import java.net.URI
+import java.net.URISyntaxException
+
+private val LOG = Logger.getInstance("MermaidLinkOpener")
+
+private const val MAX_URL_LENGTH = 2000
+
+private val ALLOWED_SCHEMES = setOf("http", "https")
+
+/**
+ * Only absolute http(s) URLs with a host may be opened: the JS→Kotlin channels are
+ * callable by any script in the preview page, so `file:`, `javascript:`, `jetbrains:`
+ * (IDE protocol handler) and other OS schemes must never reach the OS.
+ */
+internal fun isSafeExternalUrl(url: String): Boolean {
+    val trimmed = url.trim()
+    if (trimmed.isEmpty() || trimmed.length > MAX_URL_LENGTH) return false
+    val uri = try {
+        URI(trimmed)
+    } catch (e: URISyntaxException) {
+        return false
+    }
+    val scheme = uri.scheme?.lowercase() ?: return false
+    return scheme in ALLOWED_SCHEMES && uri.host != null
+}
+
+/** Opens a validated link in the system browser. Safe to call from any thread. */
+internal fun openExternalLink(url: String) {
+    if (!isSafeExternalUrl(url)) {
+        LOG.warn("Blocked opening non-http(s) link from Mermaid preview: '${url.take(200)}'")
+        return
+    }
+    ApplicationManager.getApplication().invokeLater {
+        BrowserUtil.browse(url.trim())
+    }
+}

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidPreviewPanel.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidPreviewPanel.kt
@@ -2,6 +2,7 @@ package com.alextdev.mermaidvisualizer.editor
 
 import com.alextdev.mermaidvisualizer.copyPngToClipboard
 import com.alextdev.mermaidvisualizer.copySvgToClipboard
+import com.alextdev.mermaidvisualizer.openExternalLink
 import com.alextdev.mermaidvisualizer.saveDiagramToFile
 import com.alextdev.mermaidvisualizer.settings.MermaidSettings
 import com.intellij.openapi.Disposable
@@ -16,8 +17,11 @@ import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
+import org.cef.handler.CefLifeSpanHandlerAdapter
 import org.cef.handler.CefLoadHandler
 import org.cef.handler.CefLoadHandlerAdapter
+import org.cef.handler.CefRequestHandlerAdapter
+import org.cef.network.CefRequest
 import java.io.IOException
 import java.util.Base64
 import javax.swing.JComponent
@@ -39,6 +43,7 @@ internal class MermaidPreviewPanel(
     private val copyPngQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private val saveQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private val errorQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
+    private val openLinkQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private var errorCallback: ((String) -> Unit)? = null
 
     val component: JComponent get() = browser.component
@@ -50,6 +55,7 @@ internal class MermaidPreviewPanel(
         Disposer.register(parentDisposable, copyPngQuery)
         Disposer.register(parentDisposable, saveQuery)
         Disposer.register(parentDisposable, errorQuery)
+        Disposer.register(parentDisposable, openLinkQuery)
 
         scrollQuery.addHandler { fractionStr ->
             val fraction = fractionStr.toDoubleOrNull()
@@ -87,6 +93,11 @@ internal class MermaidPreviewPanel(
             null
         }
 
+        openLinkQuery.addHandler { url ->
+            openExternalLink(url)
+            null
+        }
+
         browser.jbCefClient.addLoadHandler(object : CefLoadHandlerAdapter() {
             override fun onLoadEnd(cefBrowser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
                 if (frame?.isMain == true) {
@@ -99,6 +110,7 @@ internal class MermaidPreviewPanel(
                         injectScrollBridge()
                         injectExportBridges()
                         injectErrorBridge()
+                        injectOpenLinkBridge()
                         pendingRender?.invoke()
                         pendingRender = null
                     }
@@ -131,6 +143,37 @@ internal class MermaidPreviewPanel(
                         0,
                     )
                 }
+            }
+        }, browser.cefBrowser)
+
+        browser.jbCefClient.addLifeSpanHandler(object : CefLifeSpanHandlerAdapter() {
+            override fun onBeforePopup(
+                cefBrowser: CefBrowser?,
+                frame: CefFrame?,
+                targetUrl: String?,
+                targetFrameName: String?,
+            ): Boolean {
+                // Mermaid links default to target="_blank" — open externally, never a JCEF popup.
+                if (targetUrl != null) openExternalLink(targetUrl)
+                return true
+            }
+        }, browser.cefBrowser)
+
+        browser.jbCefClient.addRequestHandler(object : CefRequestHandlerAdapter() {
+            override fun onBeforeBrowse(
+                cefBrowser: CefBrowser?,
+                frame: CefFrame?,
+                request: CefRequest?,
+                userGesture: Boolean,
+                isRedirect: Boolean,
+            ): Boolean {
+                // The page is fully inlined — any http(s) navigation is a link escaping the JS handler.
+                val url = request?.url ?: return false
+                if (url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)) {
+                    openExternalLink(url)
+                    return true
+                }
+                return false
             }
         }, browser.cefBrowser)
 
@@ -196,6 +239,13 @@ internal class MermaidPreviewPanel(
         val injection = errorQuery.inject("payload")
         val js = "window.__mermaidErrorBridge = function(payload) { $injection };"
         browser.cefBrowser.executeJavaScript(js, "mermaid-error-bridge", 0)
+    }
+
+    private fun injectOpenLinkBridge() {
+        if (browser.isDisposed) return
+        val injection = openLinkQuery.inject("url")
+        val js = "window.__openLinkBridge = function(url) { $injection };"
+        browser.cefBrowser.executeJavaScript(js, "mermaid-open-link-bridge", 0)
     }
 
     private fun injectExportBridges() {

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidMarkdownExportHandler.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidMarkdownExportHandler.kt
@@ -2,6 +2,7 @@ package com.alextdev.mermaidvisualizer.markdown
 
 import com.alextdev.mermaidvisualizer.copyPngToClipboard
 import com.alextdev.mermaidvisualizer.copySvgToClipboard
+import com.alextdev.mermaidvisualizer.openExternalLink
 import com.alextdev.mermaidvisualizer.saveDiagramToFile
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
@@ -10,10 +11,12 @@ import org.intellij.plugins.markdown.ui.preview.BrowserPipe
 internal const val TAG_COPY_SVG = "mermaid/copy-svg"
 internal const val TAG_COPY_PNG = "mermaid/copy-png"
 internal const val TAG_SAVE = "mermaid/save"
+internal const val TAG_OPEN_LINK = "mermaid/open-link"
 
 /**
- * Subscribes to BrowserPipe messages sent from JS export toolbar buttons in `mermaid-render.js`.
- * The tag constants ([TAG_COPY_SVG], [TAG_COPY_PNG], [TAG_SAVE]) must match the strings
+ * Subscribes to BrowserPipe messages sent from JS export toolbar buttons and the
+ * diagram link handler in `mermaid-render.js`. The tag constants ([TAG_COPY_SVG],
+ * [TAG_COPY_PNG], [TAG_SAVE], [TAG_OPEN_LINK]) must match the strings
  * used in `pipe.post()` calls in that JS file.
  *
  * The [disposed] flag guards against processing messages after the editor is closed.
@@ -52,6 +55,13 @@ internal class MermaidMarkdownExportHandler(
                 ApplicationManager.getApplication().invokeLater {
                     if (!disposed) saveDiagramToFile(data, project)
                 }
+                return true
+            }
+        })
+        browserPipe.subscribe(TAG_OPEN_LINK, object : BrowserPipe.Handler {
+            override fun processMessageReceived(data: String): Boolean {
+                if (disposed) return false
+                openExternalLink(data) // schedules on the EDT itself, no invokeLater needed
                 return true
             }
         })

--- a/src/main/resources/web/mermaid-core.js
+++ b/src/main/resources/web/mermaid-core.js
@@ -272,6 +272,68 @@
         return toolbar;
     }
 
+    // --- Link click handling ---
+    // Document-level link interceptors can't see into the Shadow DOM (clicks retarget
+    // to the host), so anchor clicks are caught here and routed via openFn.
+
+    // Shadow roots persist across re-renders — install once so listeners don't stack.
+    const linkHandledRoots = new WeakSet();
+
+    function findAnchorHref(anchor) {
+        // Raw attribute first — the resolved property absolutizes relative hrefs against the page origin.
+        const raw = anchor.getAttribute('href') || anchor.getAttribute('xlink:href');
+        if (raw) return raw;
+        if (typeof anchor.href === 'string') return anchor.href;
+        return (anchor.href && anchor.href.baseVal) || '';
+    }
+
+    function isHttpUrl(url) {
+        return /^https?:\/\//i.test(url);
+    }
+
+    function installLinkHandler(shadowRoot, openFn) {
+        if (!shadowRoot || linkHandledRoots.has(shadowRoot)) return;
+        linkHandledRoots.add(shadowRoot);
+
+        let mouseDownPos = null;
+
+        shadowRoot.addEventListener('mousedown', function (e) {
+            if (e.button === 0) mouseDownPos = { x: e.clientX, y: e.clientY };
+        });
+
+        shadowRoot.addEventListener('click', function (e) {
+            const anchor = e.target && e.target.closest ? e.target.closest('a') : null;
+            if (!anchor) {
+                mouseDownPos = null;
+                return;
+            }
+            e.preventDefault();
+            e.stopPropagation();
+
+            const downPos = mouseDownPos;
+            mouseDownPos = null;
+
+            if (e.detail > 1) return; // double-click: the first click already opened
+            // Swallow clicks ending a pan drag; keyboard activation has detail 0.
+            if (e.detail !== 0 && downPos) {
+                const dist = Math.hypot(e.clientX - downPos.x, e.clientY - downPos.y);
+                if (dist > 5) return;
+            }
+
+            const url = findAnchorHref(anchor).trim();
+            if (!isHttpUrl(url)) return;
+            openFn(url);
+        });
+
+        // Block middle-click popups (they bypass the click path).
+        shadowRoot.addEventListener('auxclick', function (e) {
+            if (e.target && e.target.closest && e.target.closest('a')) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        });
+    }
+
     // --- Error info parsing ---
 
     function parseErrorInfo(err) {
@@ -299,6 +361,7 @@
         extractSvg: extractSvg,
         extractPng: extractPng,
         createExportToolbar: createExportToolbar,
+        installLinkHandler: installLinkHandler,
         parseErrorInfo: parseErrorInfo,
         getCurrentTheme: function () { return currentTheme; },
         nextRenderId: function () { return 'mermaid-render-' + (renderCounter++); },

--- a/src/main/resources/web/mermaid-render.js
+++ b/src/main/resources/web/mermaid-render.js
@@ -104,6 +104,11 @@
                         maxHeightPercent: (window.__MERMAID_CONFIG && window.__MERMAID_CONFIG.maxHeightPercent) || 60
                     });
                 }
+                // Lazy lookup — installed once per root, the pipe may not exist on first render.
+                core.installLinkHandler(container.shadowRoot, function (url) {
+                    const tools = window.__IntelliJTools;
+                    if (tools && tools.messagePipe) tools.messagePipe.post('mermaid/open-link', url);
+                });
             } else {
                 core.showError(container, shadowCss, 'Unexpected render result', renderId, isDark);
             }

--- a/src/main/resources/web/mermaid-standalone.js
+++ b/src/main/resources/web/mermaid-standalone.js
@@ -124,6 +124,9 @@
                         }
                     });
                 }
+                core.installLinkHandler(container.shadowRoot, function (url) {
+                    if (typeof window.__openLinkBridge === 'function') window.__openLinkBridge(url);
+                });
             } else {
                 core.showError(container, shadowCss, 'Unexpected render result', renderId, isDark);
                 reportRenderResult({ status: 'error', message: 'Unexpected render result', line: null, column: null }, generation);

--- a/src/main/resources/web/mermaid-zoom.js
+++ b/src/main/resources/web/mermaid-zoom.js
@@ -286,7 +286,10 @@
         viewport.addEventListener('mousemove', function (e) { onMouseMove(e, state); });
         viewport.addEventListener('mouseup', function () { onMouseUp(state); });
         viewport.addEventListener('mouseleave', function () { onMouseUp(state); });
-        viewport.addEventListener('dblclick', function () { onDblClick(state); });
+        viewport.addEventListener('dblclick', function (e) {
+            if (e.target && e.target.closest && e.target.closest('a')) return;
+            onDblClick(state);
+        });
     }
 
     // --- DOM wrapping ---

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/MermaidLinkOpenerTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/MermaidLinkOpenerTest.kt
@@ -1,0 +1,89 @@
+package com.alextdev.mermaidvisualizer
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MermaidLinkOpenerTest {
+
+    @Test
+    fun `accepts http url with host`() {
+        assertTrue(isSafeExternalUrl("http://example.com/path?q=1"))
+    }
+
+    @Test
+    fun `accepts https url with host`() {
+        assertTrue(isSafeExternalUrl("https://google.com"))
+    }
+
+    @Test
+    fun `accepts mixed case scheme`() {
+        assertTrue(isSafeExternalUrl("HTTPS://Example.COM/Page"))
+    }
+
+    @Test
+    fun `accepts url with surrounding whitespace`() {
+        assertTrue(isSafeExternalUrl("  https://example.com  "))
+    }
+
+    @Test
+    fun `rejects file scheme`() {
+        assertFalse(isSafeExternalUrl("file:///etc/hosts"))
+    }
+
+    @Test
+    fun `rejects javascript scheme`() {
+        assertFalse(isSafeExternalUrl("javascript:alert(1)"))
+    }
+
+    @Test
+    fun `rejects data scheme`() {
+        assertFalse(isSafeExternalUrl("data:text/html,<script>alert(1)</script>"))
+    }
+
+    @Test
+    fun `rejects jetbrains ide protocol scheme`() {
+        assertFalse(isSafeExternalUrl("jetbrains://idea/settings"))
+    }
+
+    @Test
+    fun `rejects mailto scheme`() {
+        assertFalse(isSafeExternalUrl("mailto:someone@example.com?bcc=evil@example.com"))
+    }
+
+    @Test
+    fun `rejects scheme-relative url`() {
+        assertFalse(isSafeExternalUrl("//evil.com/path"))
+    }
+
+    @Test
+    fun `rejects opaque https url without host`() {
+        assertFalse(isSafeExternalUrl("https:opaque-junk"))
+    }
+
+    @Test
+    fun `rejects http url without host`() {
+        assertFalse(isSafeExternalUrl("http://"))
+    }
+
+    @Test
+    fun `rejects relative url`() {
+        assertFalse(isSafeExternalUrl("some/relative/path"))
+    }
+
+    @Test
+    fun `rejects empty and blank urls`() {
+        assertFalse(isSafeExternalUrl(""))
+        assertFalse(isSafeExternalUrl("   "))
+    }
+
+    @Test
+    fun `rejects overlong url`() {
+        assertFalse(isSafeExternalUrl("https://example.com/" + "a".repeat(2000)))
+    }
+
+    @Test
+    fun `rejects unparseable url`() {
+        assertFalse(isSafeExternalUrl("https://exa mple.com"))
+    }
+}

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidCoreJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidCoreJsTest.kt
@@ -159,4 +159,53 @@ class MermaidCoreJsTest {
     fun `core js configures maxTextSize`() {
         assertTrue(jsContent.contains("maxTextSize"), "Should configure maxTextSize for large diagrams")
     }
+
+    // --- Link handling tests ---
+
+    @Test
+    fun `core js exposes installLinkHandler`() {
+        assertTrue(jsContent.contains("installLinkHandler"), "Should have installLinkHandler function")
+        assertTrue(
+            jsContent.contains("installLinkHandler: installLinkHandler"),
+            "installLinkHandler should be exposed on __mermaidCore"
+        )
+    }
+
+    @Test
+    fun `core js link handler installs once per shadow root`() {
+        assertTrue(
+            jsContent.contains("WeakSet"),
+            "Should track handled shadow roots in a WeakSet (roots persist across re-renders)"
+        )
+    }
+
+    @Test
+    fun `core js link handler intercepts anchor clicks`() {
+        assertTrue(jsContent.contains("closest('a')"), "Should find the clicked anchor via closest")
+        assertTrue(jsContent.contains("preventDefault"), "Should prevent default navigation for anchor clicks")
+    }
+
+    @Test
+    fun `core js link handler reads raw href attributes first`() {
+        assertTrue(
+            jsContent.contains("getAttribute('xlink:href')"),
+            "Should read the raw xlink:href attribute (SVG anchors, avoids origin resolution)"
+        )
+    }
+
+    @Test
+    fun `core js link handler only forwards http urls`() {
+        assertTrue(jsContent.contains("isHttpUrl"), "Should pre-filter URLs to http(s) before calling openFn")
+    }
+
+    @Test
+    fun `core js link handler guards drag and double clicks`() {
+        assertTrue(jsContent.contains("e.detail"), "Should skip the second click of a double-click via e.detail")
+        assertTrue(jsContent.contains("Math.hypot"), "Should measure mouse travel to swallow drag-ending clicks")
+    }
+
+    @Test
+    fun `core js link handler blocks middle clicks`() {
+        assertTrue(jsContent.contains("auxclick"), "Should prevent default on auxclick to block middle-click popups")
+    }
 }

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidStandaloneJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidStandaloneJsTest.kt
@@ -160,6 +160,12 @@ class MermaidStandaloneJsTest {
     }
 
     @Test
+    fun `standalone js installs link handler with openLinkBridge`() {
+        assertTrue(jsContent.contains("installLinkHandler"), "Should install the shared link click handler")
+        assertTrue(jsContent.contains("__openLinkBridge"), "Link clicks should route through the __openLinkBridge JCEF bridge")
+    }
+
+    @Test
     fun `standalone css has height 100vh`() {
         assertTrue(cssContent.contains("height: 100vh"), "Container should have height: 100vh for fit-to-window")
     }

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidZoomJsTest.kt
@@ -98,6 +98,14 @@ class MermaidZoomJsTest {
         }
 
         @Test
+        fun `double-click ignores linked nodes`() {
+            assertTrue(
+                jsContent.contains("e.target.closest('a')"),
+                "dblclick on an anchor must not toggle fit — the link handler owns those clicks"
+            )
+        }
+
+        @Test
         fun `applies CSS transform for zoom and pan`() {
             assertTrue(jsContent.contains("transform"), "Should apply CSS transform for zoom/pan")
         }

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidMarkdownExportHandlerTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidMarkdownExportHandlerTest.kt
@@ -36,5 +36,6 @@ class MermaidMarkdownExportHandlerTest {
         assertEquals("mermaid/copy-svg", TAG_COPY_SVG)
         assertEquals("mermaid/copy-png", TAG_COPY_PNG)
         assertEquals("mermaid/save", TAG_SAVE)
+        assertEquals("mermaid/open-link", TAG_OPEN_LINK)
     }
 }

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
@@ -210,4 +210,13 @@ class MermaidRenderJsExportTest {
             "Should have reInitAndRenderAll for config and theme changes"
         )
     }
+
+    @Test
+    fun `render js installs link handler posting to open-link tag`() {
+        assertTrue(jsContent.contains("installLinkHandler"), "Should install the shared link click handler")
+        assertTrue(
+            jsContent.contains("mermaid/open-link"),
+            "Link clicks should be posted on the mermaid/open-link BrowserPipe tag"
+        )
+    }
 }


### PR DESCRIPTION
- Add a shared link handler in `mermaid-core.js` (`installLinkHandler`), installed once per shadow root: document-level interceptors can't see anchor clicks through the Shadow DOM, so clicks are caught at the shadow root, filtered to http(s), and guarded against drag-ending clicks, double-clicks, and middle-click popups.
- Route link clicks to the IDE: new `mermaid/open-link` BrowserPipe tag in the Markdown preview (`MermaidMarkdownExportHandler`) and a new `__openLinkBridge` JCEF query in the standalone editor (`MermaidPreviewPanel`).
- Validate URLs on the Kotlin side (`MermaidLinkOpener`): only absolute http(s) URLs with a host, length-capped, opened via `BrowserUtil.browse` — `javascript:`, `file:`, `jetbrains:` and other schemes never reach the OS.
- Add CEF safety nets in the standalone preview: `onBeforePopup` (Mermaid links default to `target="_blank"`) and `onBeforeBrowse` open links externally instead of navigating the preview away.
- Skip the zoom fit/actual double-click toggle on linked nodes in `mermaid-zoom.js`.
- Add `MermaidLinkOpenerTest` (16 URL validation cases) and link-handler coverage in the JS content tests.