### PR TITLE
Add "Open in new tab" feature for Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ IntelliJ plugin for [Mermaid](https://mermaid.js.org/) diagrams — live preview
 - Renders ` ```mermaid ` code blocks in the built-in Markdown preview
 - Dedicated split editor for `.mmd` and `.mermaid` files with live preview
 - Zoom (Ctrl+wheel), pan (click & drag), fit-to-window & 1:1 controls
+- **Open in new tab** — pop any diagram (Markdown preview or `.mmd` editor) into its own full-size preview tab; drag it out to a separate window if you like
 - Export diagrams as SVG or PNG — copy to clipboard or save to file
 - Scroll synchronization between the text editor and the preview
 - Automatic dark/light theme detection and switching

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/MermaidDiagramOpener.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/MermaidDiagramOpener.kt
@@ -1,0 +1,92 @@
+package com.alextdev.mermaidvisualizer
+
+import com.alextdev.mermaidvisualizer.lang.MermaidFileType
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.LightVirtualFile
+import com.intellij.util.concurrency.ThreadingAssertions
+import java.util.Base64
+
+private val LOG = Logger.getInstance("MermaidDiagramOpener")
+
+private val DIAGRAM_TYPE_WORD = Regex("[A-Za-z][A-Za-z0-9-]*")
+
+private const val FALLBACK_TAB_NAME = "diagram"
+
+/**
+ * Derives the tab file name from the diagram type keyword ("flowchart TD ..." -> "flowchart.mmd"),
+ * skipping blank lines, `%%` comments/directives and a leading YAML frontmatter block.
+ * Falls back to "diagram.mmd" when no identifier-like first word is found.
+ */
+internal fun diagramTabFileName(source: String): String {
+    val lines = source.lines().map { it.trim() }
+    var i = 0
+    while (i < lines.size && (lines[i].isEmpty() || lines[i].startsWith("%%"))) i++
+    if (i < lines.size && lines[i] == "---") {
+        i++
+        while (i < lines.size && lines[i] != "---") i++
+        i++
+        while (i < lines.size && (lines[i].isEmpty() || lines[i].startsWith("%%"))) i++
+    }
+    val word = lines.getOrNull(i)?.split(' ', '\t', ':', ';', '{')?.firstOrNull()
+    val name = word?.let { DIAGRAM_TYPE_WORD.matchEntire(it)?.value } ?: FALLBACK_TAB_NAME
+    return "$name.mmd"
+}
+
+/**
+ * Opens the given Mermaid source in a separate preview-only editor tab.
+ * Must be called on the EDT (both bridge entry points dispatch via invokeLater).
+ */
+internal fun openDiagramInNewTab(source: String, project: Project?) {
+    if (project == null || project.isDisposed) {
+        LOG.warn("Cannot open diagram in a new tab: no project available")
+        notifyMermaid(project, MyMessageBundle.message("open.in.tab.failed"), NotificationType.ERROR)
+        return
+    }
+    if (source.isBlank()) {
+        LOG.warn("Open in new tab requested with blank source")
+        notifyMermaid(project, MyMessageBundle.message("open.in.tab.failed"), NotificationType.ERROR)
+        return
+    }
+    project.service<MermaidDiagramTabService>().open(source)
+}
+
+/** Markdown-preview entry point: the source travels through the BrowserPipe as base64 UTF-8. */
+internal fun openDiagramInNewTabFromBase64(b64: String, project: Project?) {
+    val source = try {
+        String(Base64.getDecoder().decode(b64), Charsets.UTF_8)
+    } catch (e: IllegalArgumentException) {
+        LOG.warn("Failed to open diagram in a new tab: invalid base64 (length=${b64.length})", e)
+        notifyMermaid(project, MyMessageBundle.message("open.in.tab.failed"), NotificationType.ERROR)
+        return
+    }
+    openDiagramInNewTab(source, project)
+}
+
+/**
+ * Opens diagram snapshots as [LightVirtualFile] tabs, deduplicated by source content so that
+ * clicking the button twice focuses the existing tab instead of stacking copies.
+ * [TextEditorWithPreview.openPreviewForFile] puts the platform DEFAULT_LAYOUT_FOR_FILE key on the
+ * file, so the MermaidSplitEditor opens in preview-only layout. EDT-only, no synchronization needed.
+ */
+@Service(Service.Level.PROJECT)
+internal class MermaidDiagramTabService(private val project: Project) {
+
+    private val openTabs = HashMap<String, LightVirtualFile>()
+
+    fun open(source: String) {
+        ThreadingAssertions.assertEventDispatchThread()
+        val fileEditorManager = FileEditorManager.getInstance(project)
+        openTabs.values.removeIf { !fileEditorManager.isFileOpen(it) }
+        val trimmed = source.trim()
+        val file = openTabs.getOrPut(trimmed) {
+            LightVirtualFile(diagramTabFileName(trimmed), MermaidFileType, trimmed)
+        }
+        TextEditorWithPreview.openPreviewForFile(project, file)
+    }
+}

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidPreviewPanel.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidPreviewPanel.kt
@@ -2,6 +2,7 @@ package com.alextdev.mermaidvisualizer.editor
 
 import com.alextdev.mermaidvisualizer.copyPngToClipboard
 import com.alextdev.mermaidvisualizer.copySvgToClipboard
+import com.alextdev.mermaidvisualizer.openDiagramInNewTab
 import com.alextdev.mermaidvisualizer.openExternalLink
 import com.alextdev.mermaidvisualizer.saveDiagramToFile
 import com.alextdev.mermaidvisualizer.settings.MermaidSettings
@@ -44,7 +45,9 @@ internal class MermaidPreviewPanel(
     private val saveQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private val errorQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private val openLinkQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
+    private val openInTabQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
     private var errorCallback: ((String) -> Unit)? = null
+    private var lastRenderedSource: String? = null
 
     val component: JComponent get() = browser.component
 
@@ -56,6 +59,7 @@ internal class MermaidPreviewPanel(
         Disposer.register(parentDisposable, saveQuery)
         Disposer.register(parentDisposable, errorQuery)
         Disposer.register(parentDisposable, openLinkQuery)
+        Disposer.register(parentDisposable, openInTabQuery)
 
         scrollQuery.addHandler { fractionStr ->
             val fraction = fractionStr.toDoubleOrNull()
@@ -98,6 +102,15 @@ internal class MermaidPreviewPanel(
             null
         }
 
+        openInTabQuery.addHandler { _ ->
+            ApplicationManager.getApplication().invokeLater {
+                if (!browser.isDisposed) {
+                    lastRenderedSource?.let { openDiagramInNewTab(it, project) }
+                }
+            }
+            null
+        }
+
         browser.jbCefClient.addLoadHandler(object : CefLoadHandlerAdapter() {
             override fun onLoadEnd(cefBrowser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
                 if (frame?.isMain == true) {
@@ -111,6 +124,7 @@ internal class MermaidPreviewPanel(
                         injectExportBridges()
                         injectErrorBridge()
                         injectOpenLinkBridge()
+                        injectOpenInTabBridge()
                         pendingRender?.invoke()
                         pendingRender = null
                     }
@@ -184,6 +198,7 @@ internal class MermaidPreviewPanel(
 
     fun render(source: String, isDark: Boolean, forceThemeRefresh: Boolean = false, generation: Long = 0L) {
         if (browser.isDisposed) return
+        lastRenderedSource = source
         val encoded = BASE64_ENCODER.encodeToString(source.toByteArray(Charsets.UTF_8))
         val themeClass = if (isDark) "dark-theme" else ""
         val configJson = service<MermaidSettings>().toJsConfigJson()
@@ -246,6 +261,13 @@ internal class MermaidPreviewPanel(
         val injection = openLinkQuery.inject("url")
         val js = "window.__openLinkBridge = function(url) { $injection };"
         browser.cefBrowser.executeJavaScript(js, "mermaid-open-link-bridge", 0)
+    }
+
+    private fun injectOpenInTabBridge() {
+        if (browser.isDisposed) return
+        val injection = openInTabQuery.inject("payload")
+        val js = "window.__openInTabBridge = function(payload) { $injection };"
+        browser.cefBrowser.executeJavaScript(js, "mermaid-open-in-tab-bridge", 0)
     }
 
     private fun injectExportBridges() {

--- a/src/main/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidMarkdownExportHandler.kt
+++ b/src/main/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidMarkdownExportHandler.kt
@@ -2,6 +2,7 @@ package com.alextdev.mermaidvisualizer.markdown
 
 import com.alextdev.mermaidvisualizer.copyPngToClipboard
 import com.alextdev.mermaidvisualizer.copySvgToClipboard
+import com.alextdev.mermaidvisualizer.openDiagramInNewTabFromBase64
 import com.alextdev.mermaidvisualizer.openExternalLink
 import com.alextdev.mermaidvisualizer.saveDiagramToFile
 import com.intellij.openapi.application.ApplicationManager
@@ -12,11 +13,12 @@ internal const val TAG_COPY_SVG = "mermaid/copy-svg"
 internal const val TAG_COPY_PNG = "mermaid/copy-png"
 internal const val TAG_SAVE = "mermaid/save"
 internal const val TAG_OPEN_LINK = "mermaid/open-link"
+internal const val TAG_OPEN_IN_TAB = "mermaid/open-in-tab"
 
 /**
  * Subscribes to BrowserPipe messages sent from JS export toolbar buttons and the
  * diagram link handler in `mermaid-render.js`. The tag constants ([TAG_COPY_SVG],
- * [TAG_COPY_PNG], [TAG_SAVE], [TAG_OPEN_LINK]) must match the strings
+ * [TAG_COPY_PNG], [TAG_SAVE], [TAG_OPEN_LINK], [TAG_OPEN_IN_TAB]) must match the strings
  * used in `pipe.post()` calls in that JS file.
  *
  * The [disposed] flag guards against processing messages after the editor is closed.
@@ -54,6 +56,15 @@ internal class MermaidMarkdownExportHandler(
                 if (disposed) return false
                 ApplicationManager.getApplication().invokeLater {
                     if (!disposed) saveDiagramToFile(data, project)
+                }
+                return true
+            }
+        })
+        browserPipe.subscribe(TAG_OPEN_IN_TAB, object : BrowserPipe.Handler {
+            override fun processMessageReceived(data: String): Boolean {
+                if (disposed) return false
+                ApplicationManager.getApplication().invokeLater {
+                    if (!disposed) openDiagramInNewTabFromBase64(data, project)
                 }
                 return true
             }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
             <li>Live rendering of <code>```mermaid</code> code blocks in the Markdown preview</li>
             <li>Dedicated split editor with live preview for <code>.mmd</code> and <code>.mermaid</code> files</li>
             <li>Zoom (<code>Ctrl+wheel</code>), pan, fit-to-window and 1:1 controls</li>
+            <li>Open in new tab — pop any diagram into its own full-size preview tab</li>
             <li>Export diagrams as SVG or PNG — copy to clipboard or save to file</li>
             <li>Automatic dark/light theme matching with your IDE</li>
             <li>All 32+ Mermaid diagram types — fully offline with bundled Mermaid.js (v11.16.0)</li>

--- a/src/main/resources/messages/MyMessageBundle.properties
+++ b/src/main/resources/messages/MyMessageBundle.properties
@@ -26,6 +26,7 @@ markdown.export.copy.png.success=PNG image copied to clipboard
 markdown.export.copy.failed=Failed to copy diagram
 markdown.export.save.success=Diagram saved: {0}
 markdown.export.save.failed=Failed to save the diagram
+open.in.tab.failed=Failed to open the diagram in a new tab
 settings.mermaid.displayName=Mermaid
 settings.mermaid.group.rendering=Rendering
 settings.mermaid.theme.label=Theme:

--- a/src/main/resources/web/mermaid-core.js
+++ b/src/main/resources/web/mermaid-core.js
@@ -25,6 +25,7 @@
     const ICON_COPY = ['M5.5 2H12.5V12.5H5.5Z', 'M3.5 4.5V14H10.5'];
     const ICON_IMAGE = ['M2 3H14V13H2Z', 'M2 11L5.5 7.5L8 10L10.5 7.5L14 11'];
     const ICON_SAVE = ['M8 2V10', 'M4.5 7L8 10.5L11.5 7', 'M3 14H13'];
+    const ICON_OPEN = ['M13.5 9.5V13.5H2.5V2.5H6.5', 'M9.5 2.5H13.5V6.5', 'M7 9L13.5 2.5'];
 
     function createSvgIcon(paths) {
         const svg = document.createElementNS(SVG_NS, 'svg');
@@ -259,6 +260,9 @@
         const toolbar = document.createElement('div');
         toolbar.className = 'mermaid-export-toolbar';
 
+        if (callbacks.openInTab) {
+            toolbar.appendChild(createToolbarButton(ICON_OPEN, 'Open in new tab', function () { callbacks.openInTab(); }));
+        }
         if (callbacks.copySvg) {
             toolbar.appendChild(createToolbarButton(ICON_COPY, 'Copy SVG', function () { handleCopySvg(callbacks); }));
         }
@@ -354,6 +358,7 @@
 
     window.__mermaidCore = {
         base64ToUtf8: base64ToUtf8,
+        utf8ToBase64: utf8ToBase64,
         createSvgIcon: createSvgIcon,
         injectSvg: injectSvg,
         showError: showError,
@@ -368,6 +373,7 @@
         SVG_NS: SVG_NS,
         ICON_COPY: ICON_COPY,
         ICON_IMAGE: ICON_IMAGE,
-        ICON_SAVE: ICON_SAVE
+        ICON_SAVE: ICON_SAVE,
+        ICON_OPEN: ICON_OPEN
     };
 })();

--- a/src/main/resources/web/mermaid-render.js
+++ b/src/main/resources/web/mermaid-render.js
@@ -79,6 +79,7 @@
         return core.createExportToolbar({
             extractSvg: function () { return core.extractSvg(container); },
             extractPng: function (scale, cb) { core.extractPng(container, scale, isDarkTheme, cb); },
+            openInTab: function () { pipe.post('mermaid/open-in-tab', core.utf8ToBase64(container.getAttribute(ATTR_SOURCE) || '')); },
             copySvg: function (b64) { pipe.post('mermaid/copy-svg', b64); },
             copyPng: function (b64) { pipe.post('mermaid/copy-png', b64); },
             save: function (payload) { pipe.post('mermaid/save', payload); }

--- a/src/main/resources/web/mermaid-standalone.js
+++ b/src/main/resources/web/mermaid-standalone.js
@@ -14,7 +14,8 @@
     function createStandaloneToolbar() {
         if (typeof window.__copySvgBridge !== 'function' &&
             typeof window.__copyPngBridge !== 'function' &&
-            typeof window.__saveBridge !== 'function') {
+            typeof window.__saveBridge !== 'function' &&
+            typeof window.__openInTabBridge !== 'function') {
             return null;
         }
 
@@ -27,6 +28,7 @@
                     return document.body.classList.contains('dark-theme');
                 }, cb);
             },
+            openInTab: typeof window.__openInTabBridge === 'function' ? function () { window.__openInTabBridge(''); } : null,
             copySvg: typeof window.__copySvgBridge === 'function' ? function (b64) { window.__copySvgBridge(b64); } : null,
             copyPng: typeof window.__copyPngBridge === 'function' ? function (b64) { window.__copyPngBridge(b64); } : null,
             save: typeof window.__saveBridge === 'function' ? function (payload) { window.__saveBridge(payload); } : null

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/MermaidDiagramOpenerTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/MermaidDiagramOpenerTest.kt
@@ -1,0 +1,86 @@
+package com.alextdev.mermaidvisualizer
+
+import com.alextdev.mermaidvisualizer.lang.MermaidFileType
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.util.Key
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.util.Base64
+
+class MermaidDiagramOpenerTest : BasePlatformTestCase() {
+
+    private val fileEditorManager get() = FileEditorManager.getInstance(project)
+
+    override fun tearDown() {
+        try {
+            fileEditorManager.openFiles.forEach { fileEditorManager.closeFile(it) }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testOpenCreatesTabWithMermaidFileType() {
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        val file = fileEditorManager.openFiles.single()
+        assertEquals(MermaidFileType, file.fileType)
+        assertEquals("flowchart.mmd", file.name)
+    }
+
+    fun testOpenedFileHasPreviewOnlyLayoutUserData() {
+        openDiagramInNewTab("sequenceDiagram\n    A->>B: Hi", project)
+        val file = fileEditorManager.openFiles.single()
+        // The platform key is Kotlin-internal but public in bytecode — reflection is the only test access.
+        val layoutKey = TextEditorWithPreview::class.java
+            .getField("DEFAULT_LAYOUT_FOR_FILE")
+            .get(null) as Key<*>
+        assertEquals(TextEditorWithPreview.Layout.SHOW_PREVIEW, file.getUserData(layoutKey))
+    }
+
+    fun testOpenTwiceSameSourceFocusesExistingTab() {
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        assertEquals(1, fileEditorManager.openFiles.size)
+    }
+
+    fun testWhitespaceVariantsDeduplicateToSameTab() {
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        openDiagramInNewTab("\n  flowchart TD\n    A --> B  \n", project)
+        assertEquals(1, fileEditorManager.openFiles.size)
+    }
+
+    fun testDifferentSourcesOpenDistinctTabs() {
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        openDiagramInNewTab("sequenceDiagram\n    A->>B: Hi", project)
+        assertEquals(2, fileEditorManager.openFiles.size)
+    }
+
+    fun testReopenAfterCloseCreatesFreshTab() {
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        fileEditorManager.closeFile(fileEditorManager.openFiles.single())
+        openDiagramInNewTab("flowchart TD\n    A --> B", project)
+        val file = fileEditorManager.openFiles.single()
+        assertTrue(fileEditorManager.isFileOpen(file))
+    }
+
+    fun testNullProjectDoesNotThrow() {
+        openDiagramInNewTab("flowchart TD\n    A --> B", null)
+    }
+
+    fun testBlankSourceDoesNotOpen() {
+        openDiagramInNewTab("   \n  ", project)
+        assertEquals(0, fileEditorManager.openFiles.size)
+    }
+
+    fun testInvalidBase64DoesNotThrow() {
+        openDiagramInNewTabFromBase64("not-valid-base64!!", project)
+        assertEquals(0, fileEditorManager.openFiles.size)
+    }
+
+    fun testBase64VariantDecodesUtf8() {
+        val source = "flowchart TD\n    A[Début] --> B[Été ☀]"
+        val b64 = Base64.getEncoder().encodeToString(source.toByteArray(Charsets.UTF_8))
+        openDiagramInNewTabFromBase64(b64, project)
+        val file = fileEditorManager.openFiles.single()
+        assertEquals(source, String(file.contentsToByteArray(), Charsets.UTF_8))
+    }
+}

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/MermaidDiagramTabNameTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/MermaidDiagramTabNameTest.kt
@@ -1,0 +1,78 @@
+package com.alextdev.mermaidvisualizer
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MermaidDiagramTabNameTest {
+
+    @Test
+    fun `simple flowchart`() {
+        assertEquals("flowchart.mmd", diagramTabFileName("flowchart TD\n    A --> B"))
+    }
+
+    @Test
+    fun `sequence diagram`() {
+        assertEquals("sequenceDiagram.mmd", diagramTabFileName("sequenceDiagram\n    Alice->>Bob: Hi"))
+    }
+
+    @Test
+    fun `diagram type with version suffix`() {
+        assertEquals("stateDiagram-v2.mmd", diagramTabFileName("stateDiagram-v2\n    [*] --> Idle"))
+    }
+
+    @Test
+    fun `pie with colon-glued first word`() {
+        assertEquals("pie.mmd", diagramTabFileName("pie: title Pets"))
+    }
+
+    @Test
+    fun `first word glued to semicolon`() {
+        assertEquals("graph.mmd", diagramTabFileName("graph;"))
+    }
+
+    @Test
+    fun `first word glued to opening brace`() {
+        assertEquals("erDiagram.mmd", diagramTabFileName("erDiagram{"))
+    }
+
+    @Test
+    fun `leading blank lines are skipped`() {
+        assertEquals("flowchart.mmd", diagramTabFileName("\n\n   \nflowchart LR\n    A --> B"))
+    }
+
+    @Test
+    fun `leading comments are skipped`() {
+        assertEquals("gantt.mmd", diagramTabFileName("%% a comment\n%% another\ngantt\n    title Plan"))
+    }
+
+    @Test
+    fun `init directive is skipped`() {
+        assertEquals("flowchart.mmd", diagramTabFileName("%%{init: {'theme': 'dark'}}%%\nflowchart TD\n    A --> B"))
+    }
+
+    @Test
+    fun `yaml frontmatter is skipped`() {
+        assertEquals("pie.mmd", diagramTabFileName("---\ntitle: Animals\n---\npie\n    \"Dogs\": 50"))
+    }
+
+    @Test
+    fun `frontmatter followed by comment`() {
+        assertEquals("timeline.mmd", diagramTabFileName("---\ntitle: X\n---\n%% comment\ntimeline\n    2024 : event"))
+    }
+
+    @Test
+    fun `blank source falls back to diagram`() {
+        assertEquals("diagram.mmd", diagramTabFileName(""))
+        assertEquals("diagram.mmd", diagramTabFileName("   \n  \n"))
+    }
+
+    @Test
+    fun `non-identifier first word falls back to diagram`() {
+        assertEquals("diagram.mmd", diagramTabFileName("123 --> B"))
+    }
+
+    @Test
+    fun `comments only falls back to diagram`() {
+        assertEquals("diagram.mmd", diagramTabFileName("%% nothing but comments"))
+    }
+}

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidCoreJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidCoreJsTest.kt
@@ -147,6 +147,28 @@ class MermaidCoreJsTest {
         assertTrue(jsContent.contains("ICON_COPY"), "Should have ICON_COPY constant")
         assertTrue(jsContent.contains("ICON_IMAGE"), "Should have ICON_IMAGE constant")
         assertTrue(jsContent.contains("ICON_SAVE"), "Should have ICON_SAVE constant")
+        assertTrue(jsContent.contains("ICON_OPEN"), "Should have ICON_OPEN constant")
+        assertTrue(jsContent.contains("ICON_OPEN: ICON_OPEN"), "ICON_OPEN should be exposed on __mermaidCore")
+    }
+
+    @Test
+    fun `core js exposes utf8ToBase64 on public API`() {
+        assertTrue(
+            jsContent.contains("utf8ToBase64: utf8ToBase64"),
+            "utf8ToBase64 should be exposed on __mermaidCore (used by the Markdown open-in-tab callback)"
+        )
+    }
+
+    @Test
+    fun `core js toolbar has open in new tab button first`() {
+        assertTrue(jsContent.contains("callbacks.openInTab"), "createExportToolbar should support an openInTab callback")
+        assertTrue(jsContent.contains("'Open in new tab'"), "Open in new tab button should have its tooltip title")
+        val openIndex = jsContent.indexOf("callbacks.openInTab")
+        val copySvgIndex = jsContent.indexOf("'Copy SVG'")
+        assertTrue(
+            openIndex in 1 until copySvgIndex,
+            "Open in new tab should be the first button of the export group"
+        )
     }
 
     @Test

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidEditorProviderTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidEditorProviderTest.kt
@@ -1,7 +1,9 @@
 package com.alextdev.mermaidvisualizer.editor
 
+import com.alextdev.mermaidvisualizer.lang.MermaidFileType
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class MermaidEditorProviderTest : BasePlatformTestCase() {
@@ -18,6 +20,11 @@ class MermaidEditorProviderTest : BasePlatformTestCase() {
     fun testAcceptsMermaidFile() {
         val file = myFixture.configureByText("test.mermaid", "flowchart LR\n    A --> B")
         assertTrue(provider.accept(project, file.virtualFile))
+    }
+
+    fun testAcceptsLightVirtualFileWithMermaidFileType() {
+        val file = LightVirtualFile("diagram.mmd", MermaidFileType, "flowchart TD\n    A --> B")
+        assertTrue(provider.accept(project, file))
     }
 
     fun testRejectsTxtFile() {

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidStandaloneJsTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/editor/MermaidStandaloneJsTest.kt
@@ -120,6 +120,19 @@ class MermaidStandaloneJsTest {
     }
 
     @Test
+    fun `standalone js wires open in tab bridge into toolbar and guard`() {
+        assertTrue(jsContent.contains("__openInTabBridge"), "Should reference __openInTabBridge")
+        assertTrue(
+            jsContent.contains("typeof window.__openInTabBridge !== 'function'"),
+            "The no-bridges guard should also consider __openInTabBridge"
+        )
+        assertTrue(
+            jsContent.contains("openInTab: typeof window.__openInTabBridge === 'function'"),
+            "The openInTab callback should be passed to core.createExportToolbar only when the bridge exists"
+        )
+    }
+
+    @Test
     fun `standalone js references toolbar CSS class for zoom init`() {
         assertTrue(jsContent.contains("mermaid-export-toolbar"), "Should reference mermaid-export-toolbar CSS class for zoom init")
     }

--- a/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
+++ b/src/test/kotlin/com/alextdev/mermaidvisualizer/markdown/MermaidRenderJsExportTest.kt
@@ -72,6 +72,19 @@ class MermaidRenderJsExportTest {
         assertTrue(jsContent.contains("mermaid/copy-svg"), "Should use mermaid/copy-svg tag")
         assertTrue(jsContent.contains("mermaid/copy-png"), "Should use mermaid/copy-png tag")
         assertTrue(jsContent.contains("mermaid/save"), "Should use mermaid/save tag")
+        assertTrue(jsContent.contains("mermaid/open-in-tab"), "Should use mermaid/open-in-tab tag")
+    }
+
+    @Test
+    fun `render js open in tab sends base64 source from data-source attribute`() {
+        assertTrue(
+            jsContent.contains("pipe.post('mermaid/open-in-tab'"),
+            "Open in new tab button should post the source to Kotlin via messagePipe"
+        )
+        assertTrue(
+            jsContent.contains("core.utf8ToBase64(container.getAttribute(ATTR_SOURCE) || '')"),
+            "Open in new tab should read the retained data-source attribute and base64-encode it"
+        )
     }
 
     @Test


### PR DESCRIPTION
- Implement functionality to open Mermaid diagrams in their own full-size preview tabs.
- Add `MermaidDiagramOpener` and `MermaidDiagramTabService` for tab management.
- Enhance `MermaidPreviewPanel` and `MermaidMarkdownExportHandler` to handle the new feature.
- Update `mermaid-core.js`, `mermaid-render.js`, and `mermaid-standalone.js` to support "Open in new tab" toolbar action.
- Introduce tests for tab naming, deduplication, and edge cases.
- Modify plugin description and README to document the new feature.